### PR TITLE
feat: web-based dotfiles management UI

### DIFF
--- a/.claude/commands/checkup.md
+++ b/.claude/commands/checkup.md
@@ -1,0 +1,71 @@
+# System Prompt / Command Protocol for Claude: Autonomous Project Analyzer & Test Refiner
+
+## Role & Objective
+
+You are an expert software engineer, test architect, and autonomous debugging agent. Your objective is to thoroughly analyze the provided project codebase, identify functional or structural defects, ensure the test suite is robust and fully reflective of the application's current state, and iteratively fix any discrepancies or failures until the entire test suite passes perfectly ("all green").
+
+---
+
+## Operating Instructions & Workflow
+
+You must execute the following workflow sequentially. Do not skip any phases. If you encounter errors, you must automatically diagnose them, implement corrections, and re-evaluate.
+
+### Phase 1: Project Exploration & Architecture Mapping
+
+1. **Discover & Map:** Scan the project root directory to understand the tech stack, programming language, frameworks, and project structure.
+2. **Configuration Audit:** Identify the configuration files (e.g., `package.json`, `requirements.txt`, `pom.xml`, `pyproject.toml`, `go.mod`, `phpunit.xml`, `jest.config.js`).
+3. **Locate Tests:** Identify where the test suite is located and determine the exact commands needed to execute unit, integration, and end-to-end tests.
+
+### Phase 2: Static Analysis & Issue Identification
+
+1. **Codebase Review:** Scan the source code for:
+   - Logic bugs, edge-case vulnerabilities, or potential runtime errors.
+   - Code smells, anti-patterns, or structural deviations from industry best practices.
+   - Dead code or unimplemented stubs that lack test coverage.
+2. **Discrepancy Check:** Compare the source code behavior against what the existing tests are asserting. Identify if the tests are outdated, missing coverage for newer features, or falsely passing due to heavy mocking/stubbing.
+
+### Phase 3: Test Verification & Initial Execution
+
+1. **Baseline Run:** Execute the full test suite using the appropriate environment commands.
+2. **Categorize Results:**
+   - **Green (Passing):** Move to checking coverage and alignment with actual code state.
+   - **Red (Failing):** Note the exact failure messages, stack traces, and the files responsible.
+   - **Missing Tests:** Identify critical code paths or recent modifications that completely lack test files.
+
+### Phase 4: The Iterative "Green Loop" (Fix & Rerun)
+
+Enter a strict loop execution block if any test fails, if code coverage is inadequate, or if tests do not reflect the current codebase reality:
+
+```
+WHILE (Tests are Failing OR Code-Test Discrepancies Exist):
+    1. Analyze the root cause of the failure or discrepancy.
+    2. Determine whether the source code is broken or if the test itself is outdated/incorrect relative to the intended application state.
+    3. Implement the minimal, clean, and robust fix required:
+       - Fix the application bug, OR
+       - Update/Rewrite the test to match the correct application behavior, OR
+       - Add missing test cases for uncovered code blocks.
+    4. Re-run the test suite.
+    5. Document the iteration:
+       - What broke?
+       - What was fixed?
+       - What is the current test suite outcome?
+```
+
+_Note: Do not break this loop until all tests pass successfully without breaking existing functionality (prevent regressions)._
+
+### Phase 5: Final Evaluation & Reporting
+
+Once the loop terminates and all tests are green, provide a comprehensive summary containing:
+
+1. **System Health Report:** A complete overview of the codebase state.
+2. **Applied Fixes Log:** A detailed list of all modifications made to both the application code and the test suite during the iteration process.
+3. **Test Status & Coverage:** Confirmation that 100% of the tests pass, along with details on any updated metrics or expanded test coverage.
+
+---
+
+## Rules of Engagement & Constraints
+
+- **Preserve Intended Behavior:** Do not change application features or business logic to make a test pass unless the business logic itself is explicitly broken or buggy.
+- **No Swallowing Errors:** Do not use empty catch blocks, muted assertions, or broad try-except blocks simply to force a test to go green.
+- **Clean Code Principles:** All fixes (both in source and test files) must adhere to proper formatting, typing, and architectural patterns present in the project.
+- **Incremental Commits/Steps:** Modify files incrementally and run tests frequently to isolate the impact of your changes.

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 .env.local
 *.swp
 *.swo
+
+# Auto-generated conflict backups (ISO timestamp dirs created by the web UI)
+backup/[0-9][0-9][0-9][0-9]-*/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ GNU Stow symlinks packages from `stow/*/` into `$HOME`. The `stow/` directory co
 
 - **zsh** — `.zshrc`, `.zprofile`, `.ideavimrc`, Oh My Zsh theme/plugins
 - **git** — `.gitconfig`, `.gitignore_global`
-- **config** — `.config/nvim/`, `.config/ghostty/`, `.config/rectangle/`, `.config/mise/`
+- **config** — `.config/nvim/`, `.config/ghostty/`, `.config/mise/`
 - **apps** — `.tmux.conf`, `.aerospace.toml`, `.dir_colors`, `.crontab`, `~/Library/` app configs
 - **work** — `.work.zsh` (work-specific aliases and env vars)
 
@@ -62,14 +62,14 @@ Each package maps directly to `$HOME` layout. Adding a file at `stow/zsh/.zshrc`
 
 ### Toolchain
 
-| Tool | Role |
-|------|------|
-| **GNU Stow** | Symlink manager — the core mechanism |
-| **Just** | Task runner wrapping all installation steps |
-| **Homebrew** | System packages and apps (`install/BrewFile`) |
-| **Mise** | Language runtime manager (Node, Python, Ruby, etc.) |
-| **Oh My Zsh** | Zsh plugin ecosystem |
-| **Starship** | Shell prompt (overrides OMZ theme) |
+| Tool          | Role                                                |
+| ------------- | --------------------------------------------------- |
+| **GNU Stow**  | Symlink manager — the core mechanism                |
+| **Just**      | Task runner wrapping all installation steps         |
+| **Homebrew**  | System packages and apps (`install/BrewFile`)       |
+| **Mise**      | Language runtime manager (Node, Python, Ruby, etc.) |
+| **Oh My Zsh** | Zsh plugin ecosystem                                |
+| **Starship**  | Shell prompt (overrides OMZ theme)                  |
 
 ### NeoVim Config
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,20 @@ stow -d stow -t ~ zsh          # Symlink only the zsh package
 stow -d stow -t ~ -D config    # Remove symlinks for the config package
 ```
 
+## Web Interface
+
+A local web UI lives in `web/` for managing symlinks via browser instead of the CLI.
+
+```bash
+cd web && npm install   # first time only
+just web               # → http://localhost:3131
+```
+
+- **`web/server.js`** — Express backend; scans stow packages, runs whitelisted `just` commands, streams output via SSE, handles backup/rollback
+- **`web/public/`** — Vanilla JS + Catppuccin Mocha dark UI (no build step)
+
+The scanner resolves both file-level and directory-level stow symlinks (stow tree-folding). Auto-generated conflict backups (`backup/YYYY-MM-DD*/`) are git-ignored; named backups like `Raise2` are tracked.
+
 ## Architecture
 
 ### Dotfile Management Flow

--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ Shell config and custom NeoVim setup are now symlinked. Open a fresh terminal se
 
 ---
 
+## Web interface
+
+A local web UI is available for managing symlinks without touching the CLI.
+
+```bash
+cd ~/dotfiles/web && npm install   # first time only
+just web                           # → http://localhost:3131
+```
+
+**What it does:**
+- Scans all stow packages and shows each file as `linked / missing / conflict`
+- Dry-run preview, backup-before-overwrite, install, and remove — per package or all at once
+- Streams real-time output for every `just` command via a built-in terminal panel
+- Backup history with one-click rollback
+
+> Timestamped conflict backups land in `backup/YYYY-MM-DD.../` and are git-ignored.
+
+---
+
 ## Day-to-day commands
 
 ```bash

--- a/install/Justfile
+++ b/install/Justfile
@@ -4,6 +4,10 @@
 default:
 	@just --list
 
+# Start the web interface at http://localhost:3131
+web:
+	@cd $HOME/dotfiles/web && npm start
+
 # Configure macOS defaults
 os:
 	@bash macos.sh

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,830 @@
+{
+  "name": "dotfiles-manager",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dotfiles-manager",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dotfiles-manager",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Web UI for managing dotfiles installation via GNU Stow",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node --watch server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -1,0 +1,482 @@
+'use strict';
+
+// ── State ────────────────────────────────────────────────────────────────────
+let packages     = [];
+let selectedPkgs = new Set();
+let homeDir      = '';
+let isTermOpen   = false;
+
+const PKG_ICONS = { zsh: '🐚', git: '🔀', config: '⚙', apps: '📦', work: '💼' };
+
+// ── Bootstrap ────────────────────────────────────────────────────────────────
+document.addEventListener('DOMContentLoaded', async () => {
+  setupTabs();
+  setupTerminal();
+  setupButtons();
+  await loadInfo();
+  loadPackages();
+  loadActions();
+});
+
+// ── Info / header ─────────────────────────────────────────────────────────────
+async function loadInfo() {
+  try {
+    const info = await api('/api/info');
+    homeDir = info.homeDir;
+    document.getElementById('dotfiles-path').textContent = info.dotfilesDir;
+  } catch (e) {
+    console.error('loadInfo:', e);
+  }
+}
+
+// ── Packages ─────────────────────────────────────────────────────────────────
+async function loadPackages() {
+  document.getElementById('packages-grid').innerHTML = '<div class="loading">Scanning packages…</div>';
+  try {
+    packages = await api('/api/packages');
+    renderPackages();
+    updateStatusPills();
+    updateSetupBanner();
+  } catch (e) {
+    document.getElementById('packages-grid').innerHTML =
+      `<div class="loading" style="color:var(--red)">Error: ${e.message}</div>`;
+  }
+}
+
+function renderPackages() {
+  const grid = document.getElementById('packages-grid');
+  grid.innerHTML = '';
+  for (const pkg of packages) grid.appendChild(makePackageCard(pkg));
+}
+
+function makePackageCard(pkg) {
+  const linked   = pkg.files.filter(f => f.status === 'linked').length;
+  const missing  = pkg.files.filter(f => f.status === 'missing').length;
+  const conflict = pkg.files.filter(f => f.status === 'conflict').length;
+  const broken   = pkg.files.filter(f => f.status === 'broken').length;
+  const sel      = selectedPkgs.has(pkg.name);
+
+  const card = el('div', `pkg-card${sel ? ' selected' : ''}`, { 'data-pkg': pkg.name });
+
+  const statsHtml = [
+    linked   > 0 ? `<span class="stat stat-linked">${linked} linked</span>`     : '',
+    missing  > 0 ? `<span class="stat stat-missing">${missing} missing</span>`  : '',
+    conflict > 0 ? `<span class="stat stat-conflict">${conflict} conflict</span>` : '',
+    broken   > 0 ? `<span class="stat stat-broken">${broken} broken</span>`     : '',
+  ].join('') || `<span class="stat" style="color:var(--overlay0)">${pkg.files.length} files</span>`;
+
+  const filesHtml = pkg.files.map(f => {
+    const destDisplay = homeDir ? f.dest.replace(homeDir, '~') : f.dest;
+    return `<div class="file-row">
+      <span class="status-dot dot-${f.status}" title="${f.status}"></span>
+      <span class="file-rel">${f.rel}</span>
+      <span class="file-dest" title="${f.dest}">${destDisplay}</span>
+    </div>`;
+  }).join('');
+
+  card.innerHTML = `
+    <div class="pkg-header">
+      <input type="checkbox" class="pkg-cb" ${sel ? 'checked' : ''} title="Select ${pkg.name}">
+      <span class="pkg-icon">${PKG_ICONS[pkg.name] || '📄'}</span>
+      <span class="pkg-name">${pkg.name}</span>
+      <div class="pkg-stats">${statsHtml}</div>
+      <button class="pkg-expand" title="Show files">▼</button>
+    </div>
+    <div class="pkg-files">${filesHtml || '<div class="loading">Empty package</div>'}</div>
+  `;
+
+  const cb       = card.querySelector('.pkg-cb');
+  const expand   = card.querySelector('.pkg-expand');
+  const fileList = card.querySelector('.pkg-files');
+
+  cb.addEventListener('change', e => {
+    e.stopPropagation();
+    e.target.checked ? selectedPkgs.add(pkg.name) : selectedPkgs.delete(pkg.name);
+    card.classList.toggle('selected', e.target.checked);
+    syncSelectAll();
+  });
+
+  expand.addEventListener('click', e => {
+    e.stopPropagation();
+    const open = fileList.classList.toggle('open');
+    expand.textContent = open ? '▲' : '▼';
+  });
+
+  return card;
+}
+
+function updateStatusPills() {
+  let linked = 0, missing = 0, conflict = 0;
+  for (const pkg of packages) {
+    for (const f of pkg.files) {
+      if (f.status === 'linked') linked++;
+      else if (f.status === 'missing') missing++;
+      else conflict++;
+    }
+  }
+  document.getElementById('pill-linked').textContent   = `${linked} linked`;
+  document.getElementById('pill-missing').textContent  = `${missing} missing`;
+  document.getElementById('pill-conflict').textContent = `${conflict} conflicts`;
+}
+
+function updateSetupBanner() {
+  const total   = packages.reduce((s, p) => s + p.files.length, 0);
+  const missing = packages.reduce((s, p) => s + p.files.filter(f => f.status === 'missing').length, 0);
+  const banner  = document.getElementById('setup-banner');
+  banner.classList.toggle('hidden', missing < total * 0.4 || total === 0);
+}
+
+function toggleSelectAll(e) {
+  packages.forEach(p => e.target.checked ? selectedPkgs.add(p.name) : selectedPkgs.delete(p.name));
+  renderPackages();
+}
+
+function syncSelectAll() {
+  document.getElementById('select-all').checked = packages.length > 0 && packages.every(p => selectedPkgs.has(p.name));
+}
+
+function getEffectivePkgs() {
+  return selectedPkgs.size > 0 ? [...selectedPkgs] : packages.map(p => p.name);
+}
+
+// ── Stow operations ───────────────────────────────────────────────────────────
+async function doDryRun() {
+  const pkgs = getEffectivePkgs();
+  const { jobId } = await api('/api/stow', 'POST', { packages: pkgs, mode: 'dry-run' });
+  streamJob(jobId, `stow --dry-run [${pkgs.join(', ')}]`);
+}
+
+async function doBackup() {
+  const pkgs = getEffectivePkgs();
+  const conflicts = packages.filter(p => pkgs.includes(p.name)).flatMap(p => p.files).filter(f => f.status === 'conflict');
+  if (conflicts.length === 0) { showToast('No conflicting files found.', 'info'); return; }
+  const { jobId } = await api('/api/backup', 'POST', { packages: pkgs });
+  streamJob(jobId, `backup [${pkgs.join(', ')}]`);
+  afterJob(jobId, loadPackages);
+}
+
+async function doInstall() {
+  const pkgs = getEffectivePkgs();
+  const conflicts = packages.filter(p => pkgs.includes(p.name)).flatMap(p => p.files).filter(f => f.status === 'conflict');
+
+  if (conflicts.length > 0) {
+    showModal('Conflicts Detected', `${conflicts.length} existing file(s) will block the installation. Choose how to proceed:`, [
+      { label: 'Cancel',            cls: 'btn-ghost',     fn: null },
+      { label: 'Backup & Install',  cls: 'btn-success',   fn: () => doBackupAndStow(pkgs) },
+      { label: 'Stow Anyway',       cls: 'btn-warning',   fn: () => stowPkgs(pkgs) },
+    ]);
+  } else {
+    stowPkgs(pkgs);
+  }
+}
+
+async function stowPkgs(pkgs) {
+  const { jobId } = await api('/api/stow', 'POST', { packages: pkgs, mode: 'stow' });
+  streamJob(jobId, `stow [${pkgs.join(', ')}]`);
+  afterJob(jobId, loadPackages);
+}
+
+async function doBackupAndStow(pkgs) {
+  const { jobId } = await api('/api/backup-and-stow', 'POST', { packages: pkgs });
+  streamJob(jobId, `backup+stow [${pkgs.join(', ')}]`);
+  afterJob(jobId, loadPackages);
+}
+
+async function doUnstow() {
+  const pkgs = getEffectivePkgs();
+  showModal('Remove Symlinks', `Remove all managed symlinks for: ${pkgs.join(', ')}.\n\nYour dotfiles repo will NOT be modified.`, [
+    { label: 'Cancel',  cls: 'btn-ghost',  fn: null },
+    { label: 'Remove',  cls: 'btn-danger', fn: async () => {
+      const { jobId } = await api('/api/stow', 'POST', { packages: pkgs, mode: 'unstow' });
+      streamJob(jobId, `unstow [${pkgs.join(', ')}]`);
+      afterJob(jobId, loadPackages);
+    }},
+  ]);
+}
+
+// ── Quick actions ─────────────────────────────────────────────────────────────
+async function loadActions() {
+  try {
+    const cmds = await api('/api/commands');
+    renderActions(cmds);
+  } catch (e) {
+    document.getElementById('actions-grid').innerHTML =
+      `<div class="loading" style="color:var(--red)">Error: ${e.message}</div>`;
+  }
+}
+
+function renderActions(cmds) {
+  const grid = document.getElementById('actions-grid');
+  grid.innerHTML = '';
+  for (const cmd of cmds) {
+    const card = el('div', 'action-card');
+    card.innerHTML = `
+      <div class="action-card-header">
+        <span class="action-cmd">just ${cmd.cmd}</span>
+        <span class="badge ${cmd.safe ? 'badge-safe' : 'badge-caution'}">${cmd.safe ? '✓ safe' : '⚠ changes system'}</span>
+      </div>
+      <div class="action-label">${cmd.label}</div>
+      <div class="action-desc">${cmd.desc || ''}</div>
+    `;
+    card.addEventListener('click', () => triggerAction(cmd));
+    grid.appendChild(card);
+  }
+}
+
+function triggerAction(cmd) {
+  if (!cmd.safe) {
+    showModal(`Run: just ${cmd.cmd}`, `${cmd.label}\n\n${cmd.desc || ''}`, [
+      { label: 'Cancel',  cls: 'btn-ghost',   fn: null },
+      { label: 'Run',     cls: 'btn-warning',  fn: () => executeAction(cmd.cmd) },
+    ]);
+  } else {
+    executeAction(cmd.cmd);
+  }
+}
+
+async function executeAction(command) {
+  try {
+    const { jobId } = await api('/api/run', 'POST', { command });
+    streamJob(jobId, `just ${command}`);
+    if (['stow', 'stow-fresh', 'unstow', 'setup'].includes(command)) {
+      afterJob(jobId, loadPackages);
+    }
+  } catch (e) {
+    showToast(`Error: ${e.message}`, 'error');
+  }
+}
+
+// ── Backups ───────────────────────────────────────────────────────────────────
+async function loadBackups() {
+  const el = document.getElementById('backups-list');
+  el.innerHTML = '<div class="loading">Loading…</div>';
+  try {
+    const list = await api('/api/backups');
+    if (list.length === 0) {
+      el.innerHTML = '<div class="loading">No backups found. Backups are created automatically when conflicting files are moved.</div>';
+      return;
+    }
+    const wrap = document.createElement('div');
+    wrap.className = 'backup-list';
+    for (const b of list) {
+      const row = document.createElement('div');
+      row.className = 'backup-row';
+      row.innerHTML = `
+        <div style="flex:1">
+          <div class="backup-name">${b.name}</div>
+          <div class="backup-count">${b.fileCount} file(s)</div>
+        </div>
+        <button class="btn btn-secondary btn-sm" data-backup="${b.name}">↩ Rollback</button>
+      `;
+      row.querySelector('button').addEventListener('click', () => triggerRollback(b.name));
+      wrap.appendChild(row);
+    }
+    el.innerHTML = '';
+    el.appendChild(wrap);
+  } catch (e) {
+    el.innerHTML = `<div class="loading" style="color:var(--red)">Error: ${e.message}</div>`;
+  }
+}
+
+function triggerRollback(name) {
+  showModal('Rollback Backup', `Restore files from backup "${name}"?\n\nThis will remove any symlinks at those paths and copy the original files back.`, [
+    { label: 'Cancel',    cls: 'btn-ghost',  fn: null },
+    { label: 'Rollback',  cls: 'btn-danger', fn: async () => {
+      const { jobId } = await api(`/api/rollback/${encodeURIComponent(name)}`, 'POST');
+      streamJob(jobId, `rollback ${name}`);
+      afterJob(jobId, () => { loadPackages(); loadBackups(); });
+    }},
+  ]);
+}
+
+// ── Prerequisites ─────────────────────────────────────────────────────────────
+async function loadPrereqs() {
+  const container = document.getElementById('prereqs-list');
+  container.innerHTML = '<div class="loading">Checking prerequisites…</div>';
+  try {
+    const results = await api('/api/prerequisites');
+    const list = document.createElement('div');
+    list.className = 'prereq-list';
+    for (const r of results) {
+      const row = document.createElement('div');
+      row.className = 'prereq-row';
+      row.innerHTML = `
+        <span class="prereq-icon">${r.ok ? '✅' : '❌'}</span>
+        <span class="prereq-name">${r.name}</span>
+        <span class="prereq-version">${r.version || 'not found'}</span>
+      `;
+      list.appendChild(row);
+    }
+    container.innerHTML = '';
+    container.appendChild(list);
+  } catch (e) {
+    container.innerHTML = `<div class="loading" style="color:var(--red)">Error: ${e.message}</div>`;
+  }
+}
+
+// ── SSE streaming ─────────────────────────────────────────────────────────────
+const jobCallbacks = new Map(); // jobId → callback fn after completion
+
+function afterJob(jobId, fn) {
+  jobCallbacks.set(jobId, fn);
+}
+
+function streamJob(jobId, label) {
+  termOpen(label);
+  termAppend(`$ ${label}\n`, 't-info');
+
+  const es = new EventSource(`/api/jobs/${jobId}/stream`);
+
+  es.onmessage = ev => {
+    const event = JSON.parse(ev.data);
+
+    if (event.type === 'stdout') {
+      termAppend(event.data, 't-stdout');
+    } else if (event.type === 'stderr') {
+      termAppend(event.data, 't-stderr');
+    } else if (event.type === 'exit') {
+      const ok = event.data.code === 0;
+      const exitMsg = `\n[exit ${event.data.code}] ${ok ? '✓ Done' : '✗ Failed'}`;
+      termAppend(exitMsg, ok ? 't-ok' : 't-fail');
+      document.getElementById('terminal-status').textContent =
+        `${label} — ${ok ? 'succeeded' : 'failed'} (exit ${event.data.code})`;
+      showToast(`${label.slice(0, 40)} — ${ok ? 'Done ✓' : 'Failed ✗'}`, ok ? 'success' : 'error');
+      es.close();
+
+      const cb = jobCallbacks.get(jobId);
+      if (cb) { jobCallbacks.delete(jobId); setTimeout(cb, 300); }
+    }
+  };
+
+  es.onerror = () => {
+    termAppend('\n[stream closed]\n', 't-info');
+    es.close();
+  };
+}
+
+// ── Terminal ──────────────────────────────────────────────────────────────────
+function setupTerminal() {
+  const panel   = document.getElementById('terminal-panel');
+  const toggle  = document.getElementById('terminal-toggle-btn');
+  const header  = document.getElementById('terminal-toggle-area');
+  const clearBtn = document.getElementById('terminal-clear');
+
+  header.addEventListener('click', e => {
+    if (e.target === clearBtn) return; // clear button has its own handler
+    isTermOpen = !isTermOpen;
+    panel.classList.toggle('collapsed', !isTermOpen);
+    toggle.textContent = isTermOpen ? '▼' : '▲';
+  });
+
+  clearBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    document.getElementById('terminal-body').innerHTML = '';
+    document.getElementById('terminal-status').textContent = '';
+  });
+}
+
+function termOpen(label) {
+  document.getElementById('terminal-job-name').textContent = `— ${label}`;
+  const panel = document.getElementById('terminal-panel');
+  isTermOpen = true;
+  panel.classList.remove('collapsed');
+  document.getElementById('terminal-toggle-btn').textContent = '▼';
+}
+
+function termAppend(text, cls = 't-stdout') {
+  const body = document.getElementById('terminal-body');
+  const span = document.createElement('span');
+  span.className = cls;
+  span.textContent = text;
+  body.appendChild(span);
+  body.scrollTop = body.scrollHeight;
+}
+
+// ── Tabs ──────────────────────────────────────────────────────────────────────
+function setupTabs() {
+  document.querySelectorAll('.tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+      document.querySelectorAll('.tab-content').forEach(s => s.classList.remove('active'));
+      tab.classList.add('active');
+      document.getElementById(`tab-${tab.dataset.tab}`).classList.add('active');
+
+      if (tab.dataset.tab === 'backups') loadBackups();
+      if (tab.dataset.tab === 'prereqs') loadPrereqs();
+    });
+  });
+}
+
+// ── Toolbar buttons ───────────────────────────────────────────────────────────
+function setupButtons() {
+  document.getElementById('refresh-btn').addEventListener('click', loadPackages);
+  document.getElementById('select-all').addEventListener('change',  toggleSelectAll);
+  document.getElementById('btn-dry-run').addEventListener('click',  doDryRun);
+  document.getElementById('btn-backup').addEventListener('click',   doBackup);
+  document.getElementById('btn-stow').addEventListener('click',     doInstall);
+  document.getElementById('btn-unstow').addEventListener('click',   doUnstow);
+
+  // Modal keyboard / backdrop dismissal
+  document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal(); });
+  document.getElementById('modal').addEventListener('click', e => {
+    if (e.target === e.currentTarget) closeModal();
+  });
+}
+
+// ── Modal ─────────────────────────────────────────────────────────────────────
+
+function showModal(title, message, actions = []) {
+  document.getElementById('modal-title').textContent = title;
+  document.getElementById('modal-msg').textContent   = message;
+
+  const actionsEl = document.getElementById('modal-actions');
+  actionsEl.innerHTML = '';
+  for (const a of actions) {
+    const btn = document.createElement('button');
+    btn.className = `btn btn-sm ${a.cls}`;
+    btn.textContent = a.label;
+    btn.addEventListener('click', () => { closeModal(); if (a.fn) a.fn(); });
+    actionsEl.appendChild(btn);
+  }
+
+  document.getElementById('modal').classList.remove('hidden');
+}
+
+function closeModal() {
+  document.getElementById('modal').classList.add('hidden');
+}
+
+// ── Toast ─────────────────────────────────────────────────────────────────────
+function showToast(message, type = 'info') {
+  const container = document.getElementById('toasts');
+  const toast = document.createElement('div');
+  toast.className = `toast toast-${type}`;
+  toast.textContent = message;
+  container.appendChild(toast);
+  setTimeout(() => {
+    toast.style.animation = 'fadeOut .3s ease forwards';
+    setTimeout(() => toast.remove(), 300);
+  }, 4000);
+}
+
+// ── API helper ────────────────────────────────────────────────────────────────
+async function api(url, method = 'GET', body = null) {
+  const res = await fetch(url, {
+    method,
+    headers: body ? { 'Content-Type': 'application/json' } : {},
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error(err.error || res.statusText);
+  }
+  return res.json();
+}
+
+// ── DOM helper ────────────────────────────────────────────────────────────────
+function el(tag, className, attrs = {}) {
+  const e = document.createElement(tag);
+  if (className) e.className = className;
+  for (const [k, v] of Object.entries(attrs)) e.setAttribute(k, v);
+  return e;
+}

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dotfiles Manager</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+
+<!-- ── Header ─────────────────────────────────────────────────────────────── -->
+<header class="header">
+  <div class="header-inner">
+    <div class="logo">
+      <svg class="logo-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+        <path d="M9 3H5a2 2 0 00-2 2v4m6-6h10a2 2 0 012 2v4M9 3v18m0 0h10a2 2 0 002-2V9M9 21H5a2 2 0 01-2-2V9m0 0h18"/>
+      </svg>
+      <div>
+        <h1>Dotfiles Manager</h1>
+        <code class="header-path" id="dotfiles-path">loading…</code>
+      </div>
+    </div>
+    <div class="header-right">
+      <div class="status-pills">
+        <span class="pill pill-green" id="pill-linked" title="Symlinks correctly in place">— linked</span>
+        <span class="pill pill-yellow" id="pill-missing" title="No file at destination — safe to install">— missing</span>
+        <span class="pill pill-red" id="pill-conflict" title="Destination exists but is not our symlink">— conflicts</span>
+      </div>
+      <button class="btn btn-ghost btn-sm" id="refresh-btn">↻ Refresh</button>
+    </div>
+  </div>
+</header>
+
+<!-- ── Navigation ─────────────────────────────────────────────────────────── -->
+<nav class="tabs">
+  <button class="tab active" data-tab="packages">Packages</button>
+  <button class="tab" data-tab="actions">Quick Actions</button>
+  <button class="tab" data-tab="backups">Backups</button>
+  <button class="tab" data-tab="prereqs">System Check</button>
+</nav>
+
+<!-- ── Main ───────────────────────────────────────────────────────────────── -->
+<main class="main">
+
+  <!-- Packages Tab -->
+  <section id="tab-packages" class="tab-content active">
+    <div class="toolbar">
+      <label class="checkbox-label">
+        <input type="checkbox" id="select-all" />
+        <span>Select all packages</span>
+      </label>
+      <div class="toolbar-actions">
+        <button class="btn btn-ghost btn-sm" id="btn-dry-run" title="Preview symlinks without making changes">🔍 Dry Run</button>
+        <button class="btn btn-secondary btn-sm" id="btn-backup" title="Copy conflicting files to backup/ before overwriting">💾 Backup Conflicts</button>
+        <button class="btn btn-success btn-sm" id="btn-stow" title="Create symlinks for selected packages">⚡ Install</button>
+        <button class="btn btn-danger btn-sm" id="btn-unstow" title="Remove managed symlinks">✕ Remove</button>
+      </div>
+    </div>
+    <div id="setup-banner" class="setup-banner hidden">
+      <div class="banner-content">
+        <strong>Fresh machine detected</strong> — many files are not yet installed.
+        <span>Run <em>Quick Actions → Full MacBook Setup</em> to get started, or install individual packages below.</span>
+      </div>
+    </div>
+    <div class="packages-grid" id="packages-grid">
+      <div class="loading">Scanning packages…</div>
+    </div>
+  </section>
+
+  <!-- Quick Actions Tab -->
+  <section id="tab-actions" class="tab-content">
+    <div class="section-header">
+      <h2 class="section-title">Quick Actions</h2>
+      <p class="section-desc">Run <code>just</code> commands from <code>install/Justfile</code>. Destructive actions show a confirmation prompt.</p>
+    </div>
+    <div class="actions-grid" id="actions-grid">
+      <div class="loading">Loading commands…</div>
+    </div>
+  </section>
+
+  <!-- Backups Tab -->
+  <section id="tab-backups" class="tab-content">
+    <div class="section-header">
+      <h2 class="section-title">Backups</h2>
+      <p class="section-desc">Files saved before overwriting. Each backup is timestamped and stored in <code>backup/</code>.</p>
+    </div>
+    <div id="backups-list"><div class="loading">Loading…</div></div>
+  </section>
+
+  <!-- System Check Tab -->
+  <section id="tab-prereqs" class="tab-content">
+    <div class="section-header">
+      <h2 class="section-title">System Check</h2>
+      <p class="section-desc">Required tools for the dotfiles setup.</p>
+    </div>
+    <div id="prereqs-list"><div class="loading">Checking…</div></div>
+  </section>
+
+</main>
+
+<!-- ── Terminal Panel ──────────────────────────────────────────────────────── -->
+<div id="terminal-panel" class="terminal-panel collapsed">
+  <div class="terminal-header" id="terminal-toggle-area">
+    <div class="terminal-left">
+      <span class="terminal-dot dot-red"></span>
+      <span class="terminal-dot dot-yellow"></span>
+      <span class="terminal-dot dot-green"></span>
+      <span class="terminal-label">Terminal</span>
+      <span class="terminal-job-name" id="terminal-job-name"></span>
+    </div>
+    <div class="terminal-controls">
+      <button class="btn-icon" id="terminal-clear" title="Clear terminal">Clear</button>
+      <button class="btn-icon" id="terminal-toggle-btn">▲</button>
+    </div>
+  </div>
+  <div class="terminal-body" id="terminal-body"></div>
+  <div class="terminal-status" id="terminal-status"></div>
+</div>
+
+<!-- ── Toast Container ────────────────────────────────────────────────────── -->
+<div id="toasts" aria-live="polite"></div>
+
+<!-- ── Modal ──────────────────────────────────────────────────────────────── -->
+<div id="modal" class="modal-overlay hidden" role="dialog" aria-modal="true">
+  <div class="modal-box">
+    <h3 id="modal-title"></h3>
+    <p id="modal-msg"></p>
+    <div id="modal-actions" class="modal-actions"></div>
+  </div>
+</div>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -1,0 +1,583 @@
+/* ── Catppuccin Mocha ─────────────────────────────────────────────────────── */
+:root {
+  --base:      #1e1e2e;
+  --mantle:    #181825;
+  --crust:     #11111b;
+  --surface0:  #313244;
+  --surface1:  #45475a;
+  --surface2:  #585b70;
+  --overlay0:  #6c7086;
+  --overlay1:  #7f849c;
+  --subtext0:  #a6adc8;
+  --subtext1:  #bac2de;
+  --text:      #cdd6f4;
+  --lavender:  #b4befe;
+  --blue:      #89b4fa;
+  --sapphire:  #74c7ec;
+  --sky:       #89dceb;
+  --teal:      #94e2d5;
+  --green:     #a6e3a1;
+  --yellow:    #f9e2af;
+  --peach:     #fab387;
+  --maroon:    #eba0ac;
+  --red:       #f38ba8;
+  --mauve:     #cba6f7;
+  --pink:      #f5c2e7;
+  --rosewater: #f5e0dc;
+
+  --radius-sm: 6px;
+  --radius:    10px;
+  --radius-lg: 14px;
+}
+
+/* ── Reset ────────────────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: var(--base);
+  color: var(--text);
+  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  min-height: 100vh;
+  padding-bottom: 200px; /* room for terminal panel */
+}
+
+/* ── Header ───────────────────────────────────────────────────────────────── */
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--crust);
+  border-bottom: 1px solid var(--surface0);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 24px;
+  height: 56px;
+  gap: 16px;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.logo-icon {
+  width: 28px;
+  height: 28px;
+  color: var(--mauve);
+  flex-shrink: 0;
+}
+
+.logo h1 {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--mauve);
+  white-space: nowrap;
+}
+
+.header-path {
+  display: block;
+  font-size: 10px;
+  color: var(--overlay0);
+  margin-top: 1px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 400px;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+/* ── Status Pills ─────────────────────────────────────────────────────────── */
+.status-pills { display: flex; gap: 6px; }
+
+.pill {
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  border: 1px solid;
+  white-space: nowrap;
+}
+
+.pill-green  { background: rgba(166,227,161,.12); color: var(--green);  border-color: rgba(166,227,161,.3); }
+.pill-yellow { background: rgba(249,226,175,.12); color: var(--yellow); border-color: rgba(249,226,175,.3); }
+.pill-red    { background: rgba(243,139,168,.12); color: var(--red);    border-color: rgba(243,139,168,.3); }
+
+/* ── Tabs ─────────────────────────────────────────────────────────────────── */
+.tabs {
+  background: var(--mantle);
+  border-bottom: 1px solid var(--surface0);
+  display: flex;
+  gap: 2px;
+  padding: 0 24px;
+}
+
+.tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--subtext0);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 10px 14px;
+  transition: color .15s, border-color .15s;
+}
+
+.tab:hover  { color: var(--text); }
+.tab.active { color: var(--mauve); border-bottom-color: var(--mauve); }
+
+/* ── Main content ─────────────────────────────────────────────────────────── */
+.main {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.tab-content         { display: none; }
+.tab-content.active  { display: block; }
+
+/* ── Section header ───────────────────────────────────────────────────────── */
+.section-header { margin-bottom: 20px; }
+.section-title  { font-size: 16px; font-weight: 600; margin-bottom: 4px; }
+.section-desc   { font-size: 12px; color: var(--subtext0); }
+.section-desc code { color: var(--blue); }
+
+/* ── Setup banner ─────────────────────────────────────────────────────────── */
+.setup-banner {
+  background: rgba(249,226,175,.08);
+  border: 1px solid rgba(249,226,175,.25);
+  border-radius: var(--radius);
+  padding: 12px 16px;
+  margin-bottom: 20px;
+  font-size: 12px;
+  color: var(--yellow);
+}
+
+.banner-content { display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
+.banner-content em { color: var(--peach); font-style: normal; }
+
+/* ── Toolbar (packages tab) ───────────────────────────────────────────────── */
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.toolbar-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+/* ── Packages grid ────────────────────────────────────────────────────────── */
+.packages-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+/* ── Package card ─────────────────────────────────────────────────────────── */
+.pkg-card {
+  background: var(--mantle);
+  border: 1px solid var(--surface0);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: border-color .15s;
+}
+
+.pkg-card:hover    { border-color: var(--surface1); }
+.pkg-card.selected { border-color: var(--mauve); }
+.pkg-card.selected .pkg-name { color: var(--mauve); }
+
+.pkg-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.pkg-cb     { cursor: pointer; accent-color: var(--mauve); width: 14px; height: 14px; flex-shrink: 0; }
+.pkg-icon   { font-size: 16px; flex-shrink: 0; }
+.pkg-name   { font-weight: 600; font-size: 14px; flex: 1; color: var(--text); }
+
+.pkg-stats  { display: flex; gap: 4px; flex-wrap: wrap; }
+.stat {
+  font-size: 10px;
+  font-weight: 500;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.stat-linked   { background: rgba(166,227,161,.15); color: var(--green); }
+.stat-missing  { background: rgba(249,226,175,.15); color: var(--yellow); }
+.stat-conflict { background: rgba(243,139,168,.15); color: var(--red); }
+.stat-broken   { background: rgba(250,179,135,.15); color: var(--peach); }
+
+.pkg-expand {
+  background: none; border: none; color: var(--overlay0);
+  cursor: pointer; font-size: 11px; padding: 4px;
+  transition: color .15s; flex-shrink: 0;
+}
+.pkg-expand:hover { color: var(--text); }
+
+/* ── Package files list ───────────────────────────────────────────────────── */
+.pkg-files {
+  border-top: 1px solid var(--surface0);
+  display: none;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.pkg-files.open { display: block; }
+
+.file-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 16px;
+  border-bottom: 1px solid rgba(49,50,68,.6);
+  font-size: 11px;
+}
+.file-row:last-child { border-bottom: none; }
+
+.status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.dot-linked   { background: var(--green); }
+.dot-missing  { background: var(--yellow); }
+.dot-conflict { background: var(--red); }
+.dot-broken   { background: var(--peach); }
+
+.file-rel  { color: var(--subtext0); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.file-dest { color: var(--overlay0); font-size: 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 140px; }
+
+/* ── Buttons ──────────────────────────────────────────────────────────────── */
+.btn {
+  align-items: center;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: inline-flex;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  gap: 5px;
+  padding: 8px 14px;
+  transition: filter .15s, background .15s;
+  white-space: nowrap;
+}
+
+.btn:disabled { cursor: not-allowed; opacity: .45; }
+.btn:focus-visible { outline: 2px solid var(--mauve); outline-offset: 2px; }
+
+.btn-sm     { padding: 6px 12px; font-size: 12px; }
+.btn-primary   { background: var(--blue);    color: var(--crust); }
+.btn-success   { background: var(--green);   color: var(--crust); }
+.btn-danger    { background: var(--red);     color: var(--crust); }
+.btn-warning   { background: var(--yellow);  color: var(--crust); }
+.btn-secondary { background: var(--surface1); color: var(--text); }
+.btn-ghost     { background: transparent; color: var(--text); border: 1px solid var(--surface1); }
+
+.btn-primary:hover:not(:disabled),
+.btn-success:hover:not(:disabled),
+.btn-danger:hover:not(:disabled),
+.btn-warning:hover:not(:disabled)  { filter: brightness(1.12); }
+
+.btn-secondary:hover:not(:disabled) { background: var(--surface2); }
+.btn-ghost:hover:not(:disabled)     { background: var(--surface0); }
+
+/* ── Actions grid ─────────────────────────────────────────────────────────── */
+.actions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 14px;
+}
+
+.action-card {
+  background: var(--mantle);
+  border: 1px solid var(--surface0);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  padding: 18px 20px;
+  transition: border-color .15s, background .15s;
+}
+
+.action-card:hover { background: var(--surface0); border-color: var(--surface1); }
+
+.action-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+  gap: 8px;
+}
+
+.action-cmd {
+  color: var(--blue);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.badge {
+  font-size: 10px;
+  font-weight: 500;
+  padding: 2px 7px;
+  border-radius: 4px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.badge-safe    { background: rgba(166,227,161,.15); color: var(--green); }
+.badge-caution { background: rgba(243,139,168,.15); color: var(--red); }
+
+.action-label { color: var(--text); font-size: 12px; font-weight: 500; margin-bottom: 4px; }
+.action-desc  { color: var(--overlay0); font-size: 11px; line-height: 1.5; }
+
+/* ── Backups ──────────────────────────────────────────────────────────────── */
+.backup-list { display: flex; flex-direction: column; gap: 10px; }
+
+.backup-row {
+  align-items: center;
+  background: var(--mantle);
+  border: 1px solid var(--surface0);
+  border-radius: var(--radius);
+  display: flex;
+  gap: 12px;
+  padding: 14px 16px;
+}
+
+.backup-name  { font-weight: 600; flex: 1; }
+.backup-count { color: var(--overlay0); font-size: 11px; }
+
+/* ── Prerequisites ────────────────────────────────────────────────────────── */
+.prereq-list { display: flex; flex-direction: column; gap: 8px; max-width: 520px; }
+
+.prereq-row {
+  align-items: center;
+  background: var(--mantle);
+  border: 1px solid var(--surface0);
+  border-radius: var(--radius);
+  display: flex;
+  gap: 12px;
+  padding: 12px 16px;
+}
+
+.prereq-icon    { font-size: 15px; }
+.prereq-name    { font-weight: 600; flex: 1; }
+.prereq-version { color: var(--overlay0); font-size: 11px; }
+
+/* ── Terminal panel ───────────────────────────────────────────────────────── */
+.terminal-panel {
+  background: var(--crust);
+  border-top: 1px solid var(--surface0);
+  bottom: 0;
+  left: 0;
+  position: fixed;
+  right: 0;
+  transition: transform .25s ease;
+  z-index: 200;
+}
+
+.terminal-panel.collapsed { transform: translateY(calc(100% - 42px)); }
+
+.terminal-header {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  height: 42px;
+  justify-content: space-between;
+  padding: 0 16px;
+  user-select: none;
+}
+
+.terminal-left  { align-items: center; display: flex; gap: 8px; }
+
+.terminal-dot {
+  border-radius: 50%;
+  height: 10px;
+  width: 10px;
+}
+.dot-red    { background: #ff5f57; }
+.dot-yellow { background: #ffbd2e; }
+.dot-green  { background: #28c840; }
+
+.terminal-label {
+  color: var(--subtext0);
+  font-size: 12px;
+  font-weight: 600;
+  margin-left: 4px;
+}
+
+.terminal-job-name {
+  color: var(--overlay0);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 400px;
+}
+
+.terminal-controls { align-items: center; display: flex; gap: 4px; }
+
+.btn-icon {
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--subtext0);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 11px;
+  padding: 4px 8px;
+  transition: background .15s, color .15s;
+}
+.btn-icon:hover { background: var(--surface0); color: var(--text); }
+
+.terminal-body {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  height: 220px;
+  line-height: 1.6;
+  overflow-y: auto;
+  padding: 10px 16px 4px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.terminal-status {
+  border-top: 1px solid var(--surface0);
+  color: var(--overlay0);
+  font-size: 10px;
+  height: 24px;
+  line-height: 24px;
+  padding: 0 16px;
+}
+
+/* Terminal output classes */
+.t-stdout  { color: var(--text); }
+.t-stderr  { color: var(--peach); }
+.t-info    { color: var(--blue); }
+.t-ok      { color: var(--green); font-weight: 600; }
+.t-fail    { color: var(--red);   font-weight: 600; }
+
+/* ── Checkbox label ───────────────────────────────────────────────────────── */
+.checkbox-label {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  font-size: 12px;
+  gap: 8px;
+}
+
+input[type="checkbox"] {
+  accent-color: var(--mauve);
+  cursor: pointer;
+  height: 14px;
+  width: 14px;
+}
+
+/* ── Loading ──────────────────────────────────────────────────────────────── */
+.loading {
+  color: var(--overlay0);
+  font-size: 12px;
+  padding: 32px;
+  text-align: center;
+}
+
+/* ── Toast ────────────────────────────────────────────────────────────────── */
+#toasts {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  position: fixed;
+  right: 16px;
+  top: 16px;
+  z-index: 1000;
+}
+
+.toast {
+  animation: slideIn .2s ease;
+  background: var(--surface0);
+  border-left: 3px solid;
+  border-radius: var(--radius);
+  box-shadow: 0 4px 24px rgba(0,0,0,.4);
+  font-size: 12px;
+  min-width: 260px;
+  max-width: 360px;
+  padding: 10px 14px;
+}
+
+.toast-success { border-color: var(--green); }
+.toast-error   { border-color: var(--red); }
+.toast-info    { border-color: var(--blue); }
+.toast-warning { border-color: var(--yellow); }
+
+@keyframes slideIn {
+  from { opacity: 0; transform: translateX(20px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes fadeOut {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+/* ── Modal ────────────────────────────────────────────────────────────────── */
+.modal-overlay {
+  align-items: center;
+  background: rgba(0,0,0,.7);
+  backdrop-filter: blur(4px);
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 500;
+}
+
+.modal-overlay.hidden { display: none; }
+
+.modal-box {
+  background: var(--mantle);
+  border: 1px solid var(--surface1);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 20px 60px rgba(0,0,0,.5);
+  max-width: 420px;
+  padding: 24px;
+  width: 90%;
+}
+
+.modal-box h3 { font-size: 15px; margin-bottom: 10px; }
+.modal-box p  { color: var(--subtext0); font-size: 12px; line-height: 1.6; margin-bottom: 20px; }
+
+.modal-actions { display: flex; gap: 8px; justify-content: flex-end; flex-wrap: wrap; }
+
+/* ── Scrollbar ────────────────────────────────────────────────────────────── */
+::-webkit-scrollbar          { height: 5px; width: 5px; }
+::-webkit-scrollbar-track    { background: var(--crust); }
+::-webkit-scrollbar-thumb    { background: var(--surface1); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--surface2); }
+
+/* ── Hidden utility ───────────────────────────────────────────────────────── */
+.hidden { display: none !important; }

--- a/web/server.js
+++ b/web/server.js
@@ -1,0 +1,360 @@
+'use strict';
+
+const express = require('express');
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { randomUUID } = require('crypto');
+
+const app = express();
+const PORT = Number(process.env.PORT) || 3131;
+
+const DOTFILES_DIR = path.resolve(__dirname, '..');
+const STOW_DIR = path.join(DOTFILES_DIR, 'stow');
+const INSTALL_DIR = path.join(DOTFILES_DIR, 'install');
+const HOME_DIR = os.homedir();
+const BACKUP_BASE = path.join(DOTFILES_DIR, 'backup');
+const PACKAGES = ['zsh', 'git', 'config', 'apps', 'work'];
+
+// Mirrors stow-local-ignore patterns (basenames and VCS dirs)
+const IGNORE_EXACT = new Set([
+  '.DS_Store', '.git', '.gitignore', '.gitmodules', '.svn', '_darcs', '.hg',
+  'CVS', 'RCS', '.cvsignore', 'COPYING',
+]);
+
+function shouldIgnore(name) {
+  if (IGNORE_EXACT.has(name)) return true;
+  if (name.endsWith('~')) return true;           // emacs backup
+  if (/^\#.*\#$/.test(name)) return true;        // emacs autosave
+  if (/^README(\..+)?$/.test(name)) return true;
+  if (/^LICENSE(\..+)?$/.test(name)) return true;
+  return false;
+}
+
+function* walkDir(dir) {
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+  for (const e of entries) {
+    if (shouldIgnore(e.name)) continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) yield* walkDir(full);
+    else yield full;
+  }
+}
+
+function symlinkStatus(src, dest) {
+  let lstat;
+  try { lstat = fs.lstatSync(dest); } catch { return 'missing'; }
+  if (!lstat.isSymbolicLink()) return 'conflict';
+  try {
+    // Resolve the symlink target and compare to src
+    const target = fs.readlinkSync(dest);
+    const resolved = path.resolve(path.dirname(dest), target);
+    return resolved === src ? 'linked' : 'conflict';
+  } catch { return 'broken'; }
+}
+
+function scanPackage(name) {
+  const pkgDir = path.join(STOW_DIR, name);
+  if (!fs.existsSync(pkgDir)) return { name, files: [], error: 'Package directory not found' };
+  const files = [];
+  for (const src of walkDir(pkgDir)) {
+    const rel = path.relative(pkgDir, src);
+    const dest = path.join(HOME_DIR, rel);
+    files.push({ rel, src, dest, status: symlinkStatus(src, dest) });
+  }
+  return { name, files };
+}
+
+// ── Job system ───────────────────────────────────────────────────────────────
+
+const jobs = new Map();
+
+function createJob(label) {
+  const id = randomUUID();
+  const job = { id, label, status: 'running', output: [], listeners: new Set(), startedAt: Date.now() };
+  jobs.set(id, job);
+  // Evict oldest jobs if over 100
+  if (jobs.size > 100) jobs.delete(jobs.keys().next().value);
+  return job;
+}
+
+function jobEmit(job, type, data) {
+  const ev = { type, data, ts: Date.now() };
+  job.output.push(ev);
+  for (const res of job.listeners) res.write(`data: ${JSON.stringify(ev)}\n\n`);
+}
+
+function jobFinish(job, code) {
+  job.status = code === 0 ? 'success' : 'failed';
+  job.exitCode = code;
+  job.finishedAt = Date.now();
+  jobEmit(job, 'exit', { code });
+  for (const res of job.listeners) res.end();
+  job.listeners.clear();
+}
+
+function runProc(job, cmd, args, cwd, extraEnv = {}) {
+  return new Promise(resolve => {
+    const proc = spawn(cmd, args, {
+      cwd,
+      shell: false,
+      env: { ...process.env, ...extraEnv },
+    });
+    proc.stdout.on('data', d => jobEmit(job, 'stdout', d.toString()));
+    proc.stderr.on('data', d => jobEmit(job, 'stderr', d.toString()));
+    proc.on('close', code => { jobFinish(job, code ?? 1); resolve(code); });
+    proc.on('error', err => {
+      jobEmit(job, 'stderr', `spawn error: ${err.message}\n`);
+      jobFinish(job, 1);
+      resolve(1);
+    });
+  });
+}
+
+// ── Whitelisted just commands ────────────────────────────────────────────────
+
+const JUST_CMDS = {
+  check:         { label: 'Check prerequisites',           safe: true,  desc: 'Verify brew, just, stow, and Xcode CLT are installed.' },
+  stow:          { label: 'Apply symlinks',                safe: false, desc: 'Symlink all packages to $HOME. Refuses to overwrite existing files.' },
+  'stow-fresh':  { label: 'First-time stow (--adopt)',     safe: false, desc: 'Adopt existing $HOME files into the repo. Clean machine only.' },
+  'stow-check':  { label: 'Dry-run stow preview',          safe: true,  desc: 'Preview what would be linked without making any changes.' },
+  unstow:        { label: 'Remove all symlinks',           safe: false, desc: 'Remove all managed symlinks. Dotfiles repo stays intact.' },
+  brew:          { label: 'Install Homebrew bundle',       safe: false, desc: 'Install all packages from install/BrewFile via Homebrew Bundle.' },
+  mise:          { label: 'Install language runtimes',     safe: false, desc: 'Install node, python, ruby, and other runtimes via mise.' },
+  os:            { label: 'Apply macOS defaults',          safe: false, desc: 'Set macOS system preferences via install/macos.sh.' },
+  doctor:        { label: 'Diagnose drift & issues',       safe: true,  desc: 'Check stow conflicts, brew drift, stale caches, compaudit.' },
+  'init-shell':  { label: 'Generate shell init files',     safe: false, desc: 'Pre-generate starship/zoxide init scripts for faster startup.' },
+  completions:   { label: 'Generate shell completions',    safe: false, desc: 'Regenerate uv/uvx zsh completions.' },
+  bench:         { label: 'Benchmark shell startup',       safe: true,  desc: 'Measure zsh startup time across 3 runs.' },
+  setup:         { label: 'Full MacBook setup',            safe: false, desc: 'Runs: check → stow-fresh → os → brew → mise → completions → init-shell.' },
+  update:        { label: 'Update all packages',           safe: false, desc: 'Run upd8r to update brew, mise, composer, mas, and rust.' },
+  'backup-agent':{ label: 'Install backup LaunchAgent',   safe: false, desc: 'Install and load the backup_secure LaunchAgent.' },
+};
+
+// ── Routes ───────────────────────────────────────────────────────────────────
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/api/info', (_, res) => res.json({
+  dotfilesDir: DOTFILES_DIR,
+  stowDir: STOW_DIR,
+  homeDir: HOME_DIR,
+  packages: PACKAGES,
+  backupBase: BACKUP_BASE,
+}));
+
+app.get('/api/packages', (_, res) => {
+  res.json(PACKAGES.map(scanPackage));
+});
+
+app.get('/api/commands', (_, res) => {
+  res.json(Object.entries(JUST_CMDS).map(([cmd, meta]) => ({ cmd, ...meta })));
+});
+
+app.get('/api/prerequisites', async (_, res) => {
+  const checks = [
+    { name: 'Homebrew', cmd: 'brew',         args: ['--version'] },
+    { name: 'Just',     cmd: 'just',         args: ['--version'] },
+    { name: 'GNU Stow', cmd: 'stow',         args: ['--version'] },
+    { name: 'Xcode CLT',cmd: 'xcode-select', args: ['-p'] },
+    { name: 'Mise',     cmd: 'mise',         args: ['--version'] },
+    { name: 'Git',      cmd: 'git',          args: ['--version'] },
+    { name: 'Node.js',  cmd: 'node',         args: ['--version'] },
+    { name: 'GPG',      cmd: 'gpg',          args: ['--version'] },
+  ];
+  const results = await Promise.all(checks.map(({ name, cmd, args }) =>
+    new Promise(resolve => {
+      const p = spawn(cmd, args, { shell: false });
+      let out = '';
+      p.stdout.on('data', d => out += d.toString());
+      p.stderr.on('data', d => out += d.toString());
+      p.on('close', code => resolve({ name, ok: code === 0, version: out.trim().split('\n')[0] }));
+      p.on('error', () => resolve({ name, ok: false, version: 'not found' }));
+    })
+  ));
+  res.json(results);
+});
+
+// Run a whitelisted just command
+app.post('/api/run', (req, res) => {
+  const { command } = req.body ?? {};
+  if (!JUST_CMDS[command]) return res.status(400).json({ error: `Unknown command: ${command}` });
+  const job = createJob(`just ${command}`);
+  runProc(job, 'just', [command], INSTALL_DIR);
+  res.json({ jobId: job.id });
+});
+
+// Stow / unstow / dry-run specific packages
+app.post('/api/stow', (req, res) => {
+  const { packages: pkgs = [], mode = 'stow' } = req.body ?? {};
+  const valid = pkgs.filter(p => PACKAGES.includes(p));
+  if (!valid.length) return res.status(400).json({ error: 'No valid packages specified' });
+
+  const flagMap = {
+    stow:      ['-v', '-t', HOME_DIR],
+    'dry-run': ['-n', '-v', '-t', HOME_DIR],
+    unstow:    ['-D', '-v', '-t', HOME_DIR],
+    adopt:     ['--adopt', '-v', '-t', HOME_DIR],
+  };
+  if (!flagMap[mode]) return res.status(400).json({ error: `Unknown mode: ${mode}` });
+
+  const job = createJob(`stow:${mode} [${valid.join(', ')}]`);
+  runProc(job, 'stow', [...flagMap[mode], ...valid], STOW_DIR);
+  res.json({ jobId: job.id });
+});
+
+// Backup conflicting files (copies to backup/, does not remove them)
+app.post('/api/backup', (req, res) => {
+  const { packages: pkgs = PACKAGES } = req.body ?? {};
+  const valid = pkgs.filter(p => PACKAGES.includes(p));
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const backupDir = path.join(BACKUP_BASE, ts);
+  const job = createJob(`backup [${valid.join(', ')}]`);
+
+  (async () => {
+    let n = 0;
+    for (const name of valid) {
+      const pkg = scanPackage(name);
+      const conflicts = pkg.files.filter(f => f.status === 'conflict');
+      for (const f of conflicts) {
+        try {
+          const dest = path.join(backupDir, path.relative(HOME_DIR, f.dest));
+          fs.mkdirSync(path.dirname(dest), { recursive: true });
+          fs.copyFileSync(f.dest, dest);
+          jobEmit(job, 'stdout', `  backed up: ${f.dest}\n`);
+          n++;
+        } catch (e) {
+          jobEmit(job, 'stderr', `  skip ${f.dest}: ${e.message}\n`);
+        }
+      }
+    }
+    if (n > 0) {
+      jobEmit(job, 'stdout', `\n${n} file(s) → ${backupDir}\n`);
+    } else {
+      jobEmit(job, 'stdout', 'No conflicting files found. Nothing to backup.\n');
+    }
+    jobFinish(job, 0);
+  })();
+
+  res.json({ jobId: job.id });
+});
+
+// Backup conflicts then immediately stow (atomic operation)
+app.post('/api/backup-and-stow', (req, res) => {
+  const { packages: pkgs = PACKAGES } = req.body ?? {};
+  const valid = pkgs.filter(p => PACKAGES.includes(p));
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const backupDir = path.join(BACKUP_BASE, ts);
+  const job = createJob(`backup+stow [${valid.join(', ')}]`);
+
+  (async () => {
+    jobEmit(job, 'stdout', '── Phase 1: Backup conflicts ──────────────────\n');
+    let n = 0;
+    for (const name of valid) {
+      const pkg = scanPackage(name);
+      for (const f of pkg.files.filter(f => f.status === 'conflict')) {
+        try {
+          const dest = path.join(backupDir, path.relative(HOME_DIR, f.dest));
+          fs.mkdirSync(path.dirname(dest), { recursive: true });
+          fs.copyFileSync(f.dest, dest);
+          fs.unlinkSync(f.dest);
+          jobEmit(job, 'stdout', `  moved: ${f.dest}\n`);
+          n++;
+        } catch (e) {
+          jobEmit(job, 'stderr', `  error: ${f.dest}: ${e.message}\n`);
+        }
+      }
+    }
+    jobEmit(job, 'stdout', n > 0 ? `  ${n} file(s) → ${backupDir}\n\n` : '  No conflicts.\n\n');
+
+    jobEmit(job, 'stdout', '── Phase 2: Apply symlinks ────────────────────\n');
+    await runProc(job, 'stow', ['-v', '-t', HOME_DIR, ...valid], STOW_DIR);
+  })();
+
+  res.json({ jobId: job.id });
+});
+
+// List available backups
+app.get('/api/backups', (_, res) => {
+  try {
+    if (!fs.existsSync(BACKUP_BASE)) return res.json([]);
+    const dirs = fs.readdirSync(BACKUP_BASE, { withFileTypes: true })
+      .filter(e => e.isDirectory())
+      .map(e => {
+        const dir = path.join(BACKUP_BASE, e.name);
+        let count = 0;
+        try { for (const _ of walkDir(dir)) count++; } catch {}
+        return { name: e.name, fileCount: count };
+      })
+      .sort((a, b) => b.name.localeCompare(a.name)); // newest first
+    res.json(dirs);
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// Restore a backup (copies files back, removes any symlink at dest first)
+app.post('/api/rollback/:backup', (req, res) => {
+  const name = path.basename(req.params.backup); // path.basename prevents traversal
+  const dir = path.join(BACKUP_BASE, name);
+  if (!fs.existsSync(dir)) return res.status(404).json({ error: 'Backup not found' });
+
+  const job = createJob(`rollback ${name}`);
+  (async () => {
+    let n = 0;
+    for (const src of walkDir(dir)) {
+      const rel = path.relative(dir, src);
+      const dest = path.join(HOME_DIR, rel);
+      try {
+        fs.mkdirSync(path.dirname(dest), { recursive: true });
+        try { fs.unlinkSync(dest); } catch {}
+        fs.copyFileSync(src, dest);
+        jobEmit(job, 'stdout', `  restored: ${dest}\n`);
+        n++;
+      } catch (e) {
+        jobEmit(job, 'stderr', `  error: ${dest}: ${e.message}\n`);
+      }
+    }
+    jobEmit(job, 'stdout', `\n${n} file(s) restored from ${dir}\n`);
+    jobFinish(job, 0);
+  })();
+
+  res.json({ jobId: job.id });
+});
+
+// SSE stream for a job
+app.get('/api/jobs/:id/stream', (req, res) => {
+  const job = jobs.get(req.params.id);
+  if (!job) return res.status(404).send('Job not found');
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+
+  // Replay buffered output for late subscribers
+  for (const ev of job.output) {
+    res.write(`data: ${JSON.stringify(ev)}\n\n`);
+  }
+
+  if (job.status !== 'running') return res.end();
+
+  job.listeners.add(res);
+  req.on('close', () => job.listeners.delete(res));
+});
+
+// Non-streaming job status
+app.get('/api/jobs/:id', (req, res) => {
+  const job = jobs.get(req.params.id);
+  if (!job) return res.status(404).json({ error: 'Not found' });
+  const { id, label, status, exitCode, startedAt, finishedAt } = job;
+  res.json({ id, label, status, exitCode, startedAt, finishedAt });
+});
+
+app.listen(PORT, () => {
+  console.log(`\n  Dotfiles Manager  →  http://localhost:${PORT}`);
+  console.log(`  Dotfiles root     →  ${DOTFILES_DIR}\n`);
+});

--- a/web/server.js
+++ b/web/server.js
@@ -43,16 +43,41 @@ function* walkDir(dir) {
   }
 }
 
+// Stow uses directory-level "tree folding" symlinks, e.g.:
+//   ~/.config/nvim  →  ../../dotfiles/stow/config/.config/nvim
+// Individual files under that dir aren't symlinks themselves but are
+// effectively linked. Walk dest's ancestor dirs to detect this case.
+function isEffectivelyLinked(src, dest) {
+  const parts = dest.split(path.sep).filter(Boolean);
+  for (let i = parts.length - 1; i > 0; i--) {
+    const parentDest = path.sep + parts.slice(0, i).join(path.sep);
+    const remaining  = parts.slice(i).join(path.sep);
+    let lstat;
+    try { lstat = fs.lstatSync(parentDest); } catch { continue; }
+    if (!lstat.isSymbolicLink()) continue;
+    try {
+      const target   = fs.readlinkSync(parentDest);
+      const resolved = path.resolve(path.dirname(parentDest), target);
+      if (path.join(resolved, remaining) === src) return true;
+    } catch {}
+  }
+  return false;
+}
+
 function symlinkStatus(src, dest) {
   let lstat;
-  try { lstat = fs.lstatSync(dest); } catch { return 'missing'; }
-  if (!lstat.isSymbolicLink()) return 'conflict';
-  try {
-    // Resolve the symlink target and compare to src
-    const target = fs.readlinkSync(dest);
-    const resolved = path.resolve(path.dirname(dest), target);
-    return resolved === src ? 'linked' : 'conflict';
-  } catch { return 'broken'; }
+  try { lstat = fs.lstatSync(dest); } catch {
+    return isEffectivelyLinked(src, dest) ? 'linked' : 'missing';
+  }
+  if (lstat.isSymbolicLink()) {
+    try {
+      const target   = fs.readlinkSync(dest);
+      const resolved = path.resolve(path.dirname(dest), target);
+      return resolved === src ? 'linked' : 'conflict';
+    } catch { return 'broken'; }
+  }
+  // dest is a real file — check if a parent dir symlink covers it
+  return isEffectivelyLinked(src, dest) ? 'linked' : 'conflict';
 }
 
 function scanPackage(name) {


### PR DESCRIPTION
## Summary

- Add `web/` — a local Express + SSE server with a Catppuccin Mocha dark UI for managing GNU Stow packages via browser (`http://localhost:3131`)
- Fix stow directory-level symlink detection: stow uses tree-folding (one dir symlink per directory, not per file), the scanner now walks ancestor dirs to handle this correctly
- Ignore auto-generated timestamped conflict backups (`backup/YYYY-MM-*/`) while keeping named backups like `Raise2` tracked

## Features

- **Packages tab** — scans all stow packages, classifies each file as `linked / missing / conflict / broken`, bulk install/dry-run/remove with per-package file drill-down
- **Quick Actions tab** — runs any `just` command from `install/Justfile` with streaming terminal output via SSE; destructive commands require confirmation
- **Backups tab** — lists timestamped backups with one-click rollback
- **System Check tab** — verifies brew, just, stow, Xcode CLT, mise, git, gpg

## How to run

```bash
cd ~/dotfiles/web
npm install
npm start   # → http://localhost:3131
```

## Test plan

- [ ] `npm start` launches without errors
- [ ] Packages tab shows all 5 packages with correct linked/missing/conflict counts
- [ ] Dry Run streams stow output to the terminal panel
- [ ] Backup & Install backs up conflicts then stows cleanly
- [ ] Quick Actions → `just doctor` streams output and shows exit status
- [ ] Backups tab lists backups; rollback restores files
- [ ] System Check tab shows correct pass/fail for installed tools